### PR TITLE
Add CSS handling to auto-dependency

### DIFF
--- a/processors/auto-dependency.ts
+++ b/processors/auto-dependency.ts
@@ -1,18 +1,44 @@
 /**
+ * Helper function to encapsulate the logic for creating a new element
+ *
+ * @param dependency
+ * @param document
+ * @returns
+ */
+export function createElement(dependency: string, document: any) {
+  // If the dependency contains .css
+  if (dependency.indexOf(".css") > 0) {
+    // Create a new link element
+    const newElement = document.createElement("link");
+    // Set the src attribute
+    newElement.setAttribute("href", dependency);
+    newElement.setAttribute("rel", "stylesheet");
+    // Return the element
+    return newElement;
+  }
+  // Default action (note early returns above)
+  // Create a new script element
+  const newElement = document.createElement("script");
+  // Set the src attribute
+  newElement.setAttribute("src", dependency);
+  // Return the element
+  return newElement;
+}
+
+/**
  * auto-dependency
- * 
+ *
  * Usage:
- * 
+ *
  *   import autoDependency from '<this file>'
  *   site.process(['.html'], autoDependency)
- * 
+ *
  * This will search a built dom tree for data-dependencies attributes and add a script element for each.
- * 
  */
- export default function (page: any) {
+export default function (page: any) {
   // Search for all elements on page with a data-dependencies attribute and turn into an Array
   const elementsWithDependencies = Array.from(
-    page.document.querySelectorAll('[data-dependencies]')
+    page.document.querySelectorAll("[data-dependencies]"),
   );
   // If none found, finish processing
   if (elementsWithDependencies.length === 0) return;
@@ -25,8 +51,8 @@
   const fullDependencyList = elementsWithDependencies
     .map((element: any) =>
       element
-        .getAttribute('data-dependencies')
-        .split(',')
+        .getAttribute("data-dependencies")
+        .split(",")
         .map((dependency: string) => dependency.trim())
     )
     .flat();
@@ -37,22 +63,12 @@
   const deduplicatedDependencies = Array.from(new Set(fullDependencyList));
 
   // For each deduplicated depdency
-  deduplicatedDependencies.forEach(dependency => {
-	if(dependency.indexOf('.css')>0){
-		// Create a new link element
-		const newElement = page.document.createElement('link');
-		// Set the src attribute
-		newElement.setAttribute('href', dependency);
-		newElement.setAttribute('rel', 'stylesheet');
-	}else{
-		// Create a new script element
-		const newElement = page.document.createElement('script');
-		// Set the src attribute
-		newElement.setAttribute('src', dependency);
-	}
-	// And set a data-auto-depdendency attribute
-	newElement.setAttribute('data-auto-dependency', true);
-	// Then append to the document head
-	page.document.head.appendChild(newElement);
+  deduplicatedDependencies.forEach((dependency) => {
+    // Create the new element by calling createElement
+    const newElement = createElement(dependency, page.document);
+    // And set a data-auto-depdendency attribute
+    newElement.setAttribute("data-auto-dependency", true);
+    // Then append to the document head
+    page.document.head.appendChild(newElement);
   });
 }

--- a/processors/auto-dependency.ts
+++ b/processors/auto-dependency.ts
@@ -38,13 +38,21 @@
 
   // For each deduplicated depdency
   deduplicatedDependencies.forEach(dependency => {
-    // Create a new script element
-    const newScriptElement = page.document.createElement('script');
-    // Set the src attribute
-    newScriptElement.setAttribute('src', dependency);
-    // And set a data-auto-depdendency attribute
-    newScriptElement.setAttribute('data-auto-dependency', true);
-    // Then append to the document head
-    page.document.head.appendChild(newScriptElement);
+	if(dependency.indexOf('.css')>0){
+		// Create a new link element
+		const newElement = page.document.createElement('link');
+		// Set the src attribute
+		newElement.setAttribute('href', dependency);
+		newElement.setAttribute('rel', 'stylesheet');
+	}else{
+		// Create a new script element
+		const newElement = page.document.createElement('script');
+		// Set the src attribute
+		newElement.setAttribute('src', dependency);
+	}
+	// And set a data-auto-depdendency attribute
+	newElement.setAttribute('data-auto-dependency', true);
+	// Then append to the document head
+	page.document.head.appendChild(newElement);
   });
 }


### PR DESCRIPTION
Detects if the dependency contains the string `.css` and if so, creates a `<link rel="stylesheet">` tag rather than a script tag.

Closes #1 